### PR TITLE
fix: 都道府県境界線の低ズームレベルでの二重描画を修正 (#2)

### DIFF
--- a/docs/style-nolabel.json
+++ b/docs/style-nolabel.json
@@ -100,6 +100,7 @@
       "type": "line",
       "source": "geolonia",
       "source-layer": "boundary",
+      "maxzoom": 4,
       "filter": [
         "all",
         [

--- a/docs/style-notext.json
+++ b/docs/style-notext.json
@@ -99,6 +99,7 @@
       "type": "line",
       "source": "geolonia",
       "source-layer": "boundary",
+      "maxzoom": 4,
       "filter": [
         "all",
         [

--- a/docs/style.json
+++ b/docs/style.json
@@ -100,6 +100,7 @@
       "type": "line",
       "source": "geolonia",
       "source-layer": "boundary",
+      "maxzoom": 4,
       "filter": [
         "all",
         [

--- a/layers/boundary-land-level-2.yml
+++ b/layers/boundary-land-level-2.yml
@@ -2,6 +2,7 @@ id: boundary-land-level-2
 type: line
 source: geolonia
 source-layer: boundary
+maxzoom: 4
 filter:
   - all
   - - ==


### PR DESCRIPTION
## Summary

Closes #2

- `boundary-land-level-2` レイヤーに `maxzoom: 4` を追加し、`boundary-land-level-4`（`minzoom: 4`）との描画範囲の重複を解消

## Root Cause

`boundary` ソースレイヤーにおいて admin_level 2 と admin_level 4 のジオメトリが地理的に重複しており、zoom 4 以降で両レイヤーが同時描画されるため二重線に見えていた。

## 修正内容

- `layers/boundary-land-level-2.yml` に `maxzoom: 4` を追加
- zoom 0〜3: admin_level 2 のみ描画
- zoom 4〜: admin_level 4 に切り替え（シームレスに引き継ぎ）

## 影響範囲

- `style.json`, `style-nolabel.json`, `style-notext.json` の全3スタイルに反映済み
- 副作用なし（他のレイヤーへの影響なし）

## 原因コミット

初回コミット a60f52e で全境界レイヤーが一括作成された際、zoom 範囲の重複が考慮されていなかった。

## Test plan

- [ ] zoom 0〜3 で admin_level 2 の国境線が正常に表示されることを確認
- [ ] zoom 4〜6 で都道府県境界線が二重にならず1本で表示されることを確認
- [ ] zoom 8 以降で市区町村境界線（admin_level 6）が正常に表示されることを確認
- [ ] 全3スタイル（ラベルあり・国名のみ・テキストなし）で動作確認