### PR TITLE
fix: 日本の国ラベルを最優先表示

### DIFF
--- a/docs/style-nolabel.json
+++ b/docs/style-nolabel.json
@@ -266,7 +266,33 @@
           ]
         },
         "text-max-width": 6,
-        "text-letter-spacing": 0.1
+        "text-letter-spacing": 0.1,
+        "symbol-sort-key": [
+          "case",
+          [
+            "in",
+            [
+              "get",
+              "name"
+            ],
+            [
+              "literal",
+              [
+                "日本",
+                "Japan"
+              ]
+            ]
+          ],
+          0,
+          [
+            "coalesce",
+            [
+              "get",
+              "rank"
+            ],
+            100
+          ]
+        ]
       },
       "paint": {
         "text-color": "#444444",

--- a/docs/style.json
+++ b/docs/style.json
@@ -266,7 +266,33 @@
           ]
         },
         "text-max-width": 6,
-        "text-letter-spacing": 0.1
+        "text-letter-spacing": 0.1,
+        "symbol-sort-key": [
+          "case",
+          [
+            "in",
+            [
+              "get",
+              "name"
+            ],
+            [
+              "literal",
+              [
+                "日本",
+                "Japan"
+              ]
+            ]
+          ],
+          0,
+          [
+            "coalesce",
+            [
+              "get",
+              "rank"
+            ],
+            100
+          ]
+        ]
       },
       "paint": {
         "text-color": "#444444",

--- a/layers/place-country.yml
+++ b/layers/place-country.yml
@@ -19,6 +19,19 @@ layout:
         - 20
   text-max-width: 6
   text-letter-spacing: 0.1
+  # 日本を最優先で配置し、隣国とのラベル衝突で日本が消えるのを防ぐ
+  symbol-sort-key:
+    - case
+    - - in
+      - - get
+        - name
+      - - literal
+        - ['日本', 'Japan']
+    - 0
+    - - coalesce
+      - - get
+        - rank
+      - 100
 paint:
   text-color: '#444444'
   text-halo-color: '#ffffff'


### PR DESCRIPTION
## 概要
低ズーム時に大韓民国など隣国の国ラベルが先に配置され、ラベル衝突で「日本」のラベルが表示されない問題を修正。

## 変更内容
- `layers/place-country.yml` に `symbol-sort-key` を追加。name が「日本」(または Japan) なら sort-key=0（最優先）、他は rank 順（フォールバック100）。
- style.json を charites で再ビルド。

## 動作確認基準
- [ ] 日本を中心にズーム4〜5で「日本」の国ラベルが表示される
- [ ] 隣国ラベルとの衝突時に日本が優先される
- [ ] 高ズームでラベルの見た目が崩れていない

## レビュー基準
- symbol-sort-key の式が MapLibre Style Spec 準拠（gl-style-validate でエラーなし）
- ビルド成果物 style.json が YAML と一致